### PR TITLE
Sélection valeur par défaut local sommeil ajout établissement

### DIFF
--- a/application/views/scripts/etablissement/edit.phtml
+++ b/application/views/scripts/etablissement/edit.phtml
@@ -688,6 +688,9 @@
                 // Établissement
                 case '2':
                     $('.champ_categorie, .champ_periodicite, .champ_types, .champ_effectifs, .champ_plans, .champ_adresse, .champ_commission, .champ_localsommeil, .champ_donnees_pratiques, .champ_droitpublic').show();
+                    if (!$("input[name='LOCALSOMMEIL_ETABLISSEMENTINFORMATIONS']:checked").val()) {
+                        $("input[name='LOCALSOMMEIL_ETABLISSEMENTINFORMATIONS'][value='0']").attr('checked', 'checked');
+                    }
                     break;
 
                 // Cellule

--- a/sql/migrations/2.4.30-default-root-password.sql
+++ b/sql/migrations/2.4.30-default-root-password.sql
@@ -1,2 +1,2 @@
 set names 'utf8';
-UPDATE  `utilisateur` SET  `PASSWD_UTILISATEUR` =  '0ab182b5717693a278cd986898742e766' WHERE  `utilisateur`.`ID_UTILISATEUR` =1;
+UPDATE  `utilisateur` SET  `PASSWD_UTILISATEUR` =  '0ab182b5717693a278cd986898742e76' WHERE  `utilisateur`.`ID_UTILISATEUR` =1;


### PR DESCRIPTION
Lors de la création d'un établissement de type "Établissement", aucune valeur n'est renseignée pour le local à sommeil.
Ceci cause un problème car la boîte de confirmation de sauvegarde proposant des valeurs par défaut n'affiche pas toutes les recommandations d'un coup, mais affiche en 1er la recommandation du local à sommeil puis ensuite le reste.

Le fait de forcer une sélection par défaut corrige ce problème. A noter que même si l'information n'est pas renseignée à la sauvegarde de l'établissement, la valeur "Non" est quand même insérée en base.