### PR TITLE
migration(etablissement): Affichage de la page établissement

### DIFF
--- a/application/controllers/EtablissementController.php
+++ b/application/controllers/EtablissementController.php
@@ -149,7 +149,7 @@ class EtablissementController extends Zend_Controller_Action
                 $date = date('Y-m-d');
                 $this->serviceEtablissement->save($post['ID_GENRE'], $post, $request->id, $date);
                 $this->_helper->flashMessenger(['context' => 'success', 'title' => 'Mise à jour réussie !', 'message' => 'L\'établissement a bien été mis à jour.'.$options]);
-                $this->_helper->redirector('index', null, null, ['id' => $request->id]);
+                $this->redirect('/etablissement/'.$request->id.'/informations');
             } catch (Exception $e) {
                 $this->_helper->flashMessenger(['context' => 'error', 'title' => '', 'message' => 'L\'établissement n\'a pas été mis à jour. Veuillez rééssayez. ('.$e->getMessage().')']);
             }
@@ -217,7 +217,7 @@ class EtablissementController extends Zend_Controller_Action
                     $this->_helper->flashMessenger(['context' => 'warning', 'title' => 'Ajout des établissements enfants', 'message' => "Les droits d'accès au site sont déterminés par les droits d'accès aux établissements qui le compose. Veillez à ajouter des établissements afin de garantir l'accès au site dans Prevarisc."]);
                     $this->_helper->redirector('edit', null, null, ['id' => $id_etablissement]);
                 } else {
-                    $this->_helper->redirector('index', null, null, ['id' => $id_etablissement]);
+                    $this->redirect('/etablissement/'.$id_etablissement.'/informations');
                 }
             } catch (Exception $e) {
                 $this->_helper->flashMessenger(['context' => 'error', 'title' => '', 'message' => 'L\'établissement n\'a pas été ajouté. Veuillez rééssayez. ('.$e->getMessage().')']);

--- a/application/layouts/dossier.phtml
+++ b/application/layouts/dossier.phtml
@@ -181,7 +181,7 @@ endif ?>
                     <i class='icon-folder-open icon-black'></i>
                 </a>
 
-                <a href=<?= '/etablissement/index/id/'.$this->enteteEtab['ID_ETABLISSEMENT'] ?> class='etab'>
+                <a href=<?= '/etablissement/'.$this->enteteEtab['ID_ETABLISSEMENT'].'/informations' ?> class='etab'>
                     <?= $this->enteteEtab['LIBELLE_ETABLISSEMENTINFORMATIONS'] ?>
 
                     <?php if($this->enteteEtab['adresses']) : ?>
@@ -249,7 +249,7 @@ endif ?>
             if($nbEtab > 0): ?>
                 <?php if($nbEtab == 1 && $this->enteteEtab[0]["LIBELLE_GENRE"] == "Site"): ?>
                     Site concerné :
-                    <a href=<?='/etablissement/index/id/'.$this->enteteEtab[0]['ID_ETABLISSEMENT'] ?> class='etab'>
+                    <a href=<?='/etablissement/'.$this->enteteEtab[0]['ID_ETABLISSEMENT'].'/informations' ?> class='etab'>
                         <?= $this->enteteEtab[0]['LIBELLE_ETABLISSEMENTINFORMATIONS'] ?>
                     </a>
                     <span style='font-size:10px'>#<?=$this->enteteEtab[0]['infosEtab']['general']['NUMEROID_ETABLISSEMENT'] ?></span>
@@ -275,7 +275,7 @@ endif ?>
                                 <i class='icon-folder-open icon-black'></i>
                             </a>
                             <a
-                                href=<?='/etablissement/index/id/'.$value['ID_ETABLISSEMENT'] ?>
+                                href=<?='/etablissement/'.$value['ID_ETABLISSEMENT'].'/informations' ?>
                                 class='etab'
                             >
                                 <?= $value['LIBELLE_ETABLISSEMENTINFORMATIONS'] ?>

--- a/application/layouts/etablissement.phtml
+++ b/application/layouts/etablissement.phtml
@@ -98,7 +98,7 @@
     <h2 class="page-header">
         <?php if ($this->etablissement['parents'] > 0) : ?>
             <?php foreach ($this->etablissement['parents'] as $etablissement) : ?>
-                <a href='/etablissement/index/id/<?=  $etablissement["ID_ETABLISSEMENT"] ?>'>
+                <a href='/etablissement/<?=  $etablissement["ID_ETABLISSEMENT"] ?>/informations'>
                     <?= $etablissement["LIBELLE_ETABLISSEMENTINFORMATIONS"] ?>
                 </a> -
             <?php endforeach ?>

--- a/application/layouts/etablissement.phtml
+++ b/application/layouts/etablissement.phtml
@@ -3,8 +3,8 @@
 <?php $action_name = Zend_Controller_Front::getInstance()->getRequest()->getActionName() ?>
 
 <ul class='nav nav-tabs nav-stacked menu_dashboard'>
-    <li class="<?= in_array($action_name, ['index', 'edit']) ? 'active' : '' ?>">
-        <a href='<?= $this->url(array("action"=>"index")) ?>'>
+    <li class="<?= $action_name === 'edit' ? 'active' : '' ?>">
+        <a href='/etablissement/<?= $this->etablissement['general']['ID_ETABLISSEMENT'] ?>/informations'>
             <i class="icon-info-sign icon-black"></i>
             Général
         </a>

--- a/application/layouts/includes/nav-main.phtml
+++ b/application/layouts/includes/nav-main.phtml
@@ -99,7 +99,7 @@
                 }
             }
         }).result(function(e, item) {
-            window.location.href= "/etablissement/index/id/" + item.ID_ETABLISSEMENT;
+            window.location.href= "/etablissement/" + item.ID_ETABLISSEMENT + "/informations";
         });
     });
 </script>

--- a/application/views/scripts/dossier/addetablissement.phtml
+++ b/application/views/scripts/dossier/addetablissement.phtml
@@ -1,5 +1,5 @@
 <div class='grid_14 alpha'>
-	<a href="/etablissement/index/id/<?php echo $this->infosEtab['ID_ETABLISSEMENT'] ?>"><?php echo $this->libelleEtab ?></a>
+	<a href="/etablissement/<?php echo $this->infosEtab['ID_ETABLISSEMENT'] ?>/informations"><?php echo $this->libelleEtab ?></a>
 	<input type='hidden' name='idEtablissementDossier' value="<?php echo $this->infosEtab['ID_ETABLISSEMENTDOSSIER'] ?>" />
 	&nbsp;&nbsp;
 	<span>

--- a/application/views/scripts/dossier/liees.phtml
+++ b/application/views/scripts/dossier/liees.phtml
@@ -280,7 +280,7 @@ echo "
 						echo "
 							<div class='grid_14 alpha'>
 								<input type='hidden' name='idEtablissementDossier' value='".$etab['ID_ETABLISSEMENTDOSSIER']."' />
-								<a href='/etablissement/index/id/".$etab['ID_ETABLISSEMENT']."' >".$etab['LIBELLE_ETABLISSEMENTINFORMATIONS']." &nbsp; (".$etab['LIBELLE_GENRE'].") ".( (isset($etab['pereInfos']['parents'][0]['LIBELLE_ETABLISSEMENTINFORMATIONS']))? " | ".$etab['pereInfos']['parents'][0]['LIBELLE_ETABLISSEMENTINFORMATIONS'] : "" )."</a>
+								<a href='/etablissement/".$etab['ID_ETABLISSEMENT']."/informations' >".$etab['LIBELLE_ETABLISSEMENTINFORMATIONS']." &nbsp; (".$etab['LIBELLE_GENRE'].") ".( (isset($etab['pereInfos']['parents'][0]['LIBELLE_ETABLISSEMENTINFORMATIONS']))? " | ".$etab['pereInfos']['parents'][0]['LIBELLE_ETABLISSEMENTINFORMATIONS'] : "" )."</a>
 								<input type='hidden' name='idEtablissement' value='".$etab['ID_ETABLISSEMENT']."' />
 								&nbsp;&nbsp;
 								<span>

--- a/application/views/scripts/dossier/results/etablissement.phtml
+++ b/application/views/scripts/dossier/results/etablissement.phtml
@@ -21,7 +21,7 @@
 		<?php
 			echo "<input type='checkbox' name='etabId[]' value='".$this->ID_ETABLISSEMENT."' />";
 		?>
-        <a href='/etablissement/index/id/<?php echo $this->ID_ETABLISSEMENT ?>'>
+        <a href='/etablissement/<?php echo $this->ID_ETABLISSEMENT ?>/informations'>
             <?php echo empty($this->LIBELLE_ETABLISSEMENTINFORMATIONS) ? "<em class='muted'>Libellé non renseigné</em>" : $this->LIBELLE_ETABLISSEMENTINFORMATIONS ?>
             <small>
 				<?php

--- a/application/views/scripts/etablissement/edit.phtml
+++ b/application/views/scripts/etablissement/edit.phtml
@@ -9,7 +9,7 @@
     <?php else : ?>
     <div class='pull-right'>
         <div class="btn-group">
-            <a class='btn' href="<?php echo $this->url(array('action' => 'index')) ?>">Annuler la modification</a>
+            <a class='btn' href="/etablissement/<?= $this->etablissement['general']['ID_ETABLISSEMENT'] ?>/informations">Annuler la modification</a>
             <input type='submit' class="btn btn-success" value='Sauvegarder'>
         </div>
     </div>
@@ -748,7 +748,7 @@
                     $("input[name='LOCALSOMMEIL_ETABLISSEMENTINFORMATIONS'][value=1]").attr('checked', false).change();
                     break;
 
-                // BUP 
+                // BUP
                 case '6':
                     $('.champ_icpe, .champ_effectifs, .champ_plans, .champ_adresse').show();
                     $('.etablissements_enfants, .effectif_heberge, .effectif_public').hide();

--- a/application/views/scripts/search/results/dossierTab.phtml
+++ b/application/views/scripts/search/results/dossierTab.phtml
@@ -29,7 +29,7 @@
 
     <!-- Etablissement -->
     <td class="doss-nom">
-        <a href='/etablissement/index/id/<?php echo $this->ID_ETABLISSEMENT ?>' title='<?php echo htmlspecialchars($this->LIBELLE_ETABLISSEMENTINFORMATIONS , ENT_QUOTES) ?>'>
+        <a href='/etablissement/<?php echo $this->ID_ETABLISSEMENT ?>/informations' title='<?php echo htmlspecialchars($this->LIBELLE_ETABLISSEMENTINFORMATIONS , ENT_QUOTES) ?>'>
             <?php echo $this->LIBELLE_ETABLISSEMENTINFORMATIONS  ?>
         </a>
         <br/>

--- a/application/views/scripts/search/results/etablissement.phtml
+++ b/application/views/scripts/search/results/etablissement.phtml
@@ -16,7 +16,7 @@
 
         <?php /* nom de l'établissement */ ?>
         <span class="nom-etablissement">
-            <a href='/etablissement/index/id/<?php echo $this->ID_ETABLISSEMENT ?>'>
+            <a href='/etablissement/<?php echo $this->ID_ETABLISSEMENT ?>/informations'>
                 <?php echo empty($this->LIBELLE_ETABLISSEMENTINFORMATIONS) ? "<em class='muted'>Libellé non renseigné</em>" : $this->LIBELLE_ETABLISSEMENTINFORMATIONS ?>
                 <small>
                     <?php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -735,7 +735,7 @@ parameters:
 		-
 			message: '#^Call to an undefined method Zend_Controller_Action_HelperBroker\:\:redirector\(\)\.$#'
 			identifier: method.notFound
-			count: 11
+			count: 9
 			path: application/controllers/EtablissementController.php
 
 		-


### PR DESCRIPTION
This pull request standardizes the URLs used throughout the application to access establishment ("etablissement") information pages. All links that previously used the format `/etablissement/index/id/{ID}` have been updated to use the cleaner and more RESTful format `/etablissement/{ID}/informations`. This change improves URL consistency and aligns with modern routing best practices.

**Routing and Link Updates:**

* Updated all establishment information links in layout and view files to use the new `/etablissement/{ID}/informations` URL format instead of `/etablissement/index/id/{ID}`. This affects navigation, search results, dossier displays, and parent establishment listings. [[1]](diffhunk://#diff-bc23fa15313d7a6a2e01b61b05324f5a63ceee890c635073bdec665727800699L184-R184) [[2]](diffhunk://#diff-bc23fa15313d7a6a2e01b61b05324f5a63ceee890c635073bdec665727800699L252-R252) [[3]](diffhunk://#diff-bc23fa15313d7a6a2e01b61b05324f5a63ceee890c635073bdec665727800699L278-R278) [[4]](diffhunk://#diff-bdc1324926e8618fb8ba1b2b82ac78a49ff74d726b9d5660f4ea21381fb51c62L101-R101) [[5]](diffhunk://#diff-2e1e2a1d78cdb237e8a652ef176c88a558dae957bd7f09069b31140dd559d3a0L2-R2) [[6]](diffhunk://#diff-d90ccd98c23b266827b3dfe34f191521923fdf0af86310e0655ec66baf909d95L283-R283) [[7]](diffhunk://#diff-b6644de6bb1d417c60ec022bc41d25880c11ecfac2bff46c4e4f9567b15ec174L24-R24) [[8]](diffhunk://#diff-dd9cf69c728ffdf16d6853d8113ce21b7812bbae700bfba0acb6325bc382bce5L32-R32) [[9]](diffhunk://#diff-fe63f918bdf5299c6ed89ecc366dad02c0b1d2bcdc53b36cf53adbc1509d82b9L19-R19)

* Updated the JavaScript navigation logic in `nav-main.phtml` to redirect users to the new URL format after selecting an establishment from autocomplete results.