### PR TITLE
fix(rapports): rend la balise {dateGeneration} globale

### DIFF
--- a/application/views/scripts/calendrier-des-commissions/generationcompterendu.phtml
+++ b/application/views/scripts/calendrier-des-commissions/generationcompterendu.phtml
@@ -32,6 +32,10 @@ $nomFichier = $this->commissionInfos[0]['DOCUMENT_CR'];
 if (file_exists(REAL_DATA_PATH.DIRECTORY_SEPARATOR."uploads".DIRECTORY_SEPARATOR."documents_commission".DIRECTORY_SEPARATOR.$nomFichier) && $nomFichier != ''){
 
 	$odf = new Odf(REAL_DATA_PATH.DIRECTORY_SEPARATOR."uploads".DIRECTORY_SEPARATOR."documents_commission".DIRECTORY_SEPARATOR.$nomFichier);
+
+    $dateDuJour = (new Zend_Date())->get(Zend_Date::DAY." ".Zend_Date::MONTH_NAME." ".Zend_Date::YEAR);
+    addChamp($odf,'dateGeneration', $dateDuJour);
+
 	$dossInfos = $odf->setSegment('dossierInfos');
 
 	foreach($this->dossierComm as $val => $dossierInfos){
@@ -52,9 +56,6 @@ if (file_exists(REAL_DATA_PATH.DIRECTORY_SEPARATOR."uploads".DIRECTORY_SEPARATOR
 				addChamp($dossInfos,'objetDossier', $dossierInfos['OBJET_DOSSIER']);
 				addChamp($dossInfos,'natureDossier', $dossierInfos["LIBELLE_DOSSIERNATURE"]);
                 addChamp($dossInfos,'observationDossier', $dossierInfos['OBSERVATION_DOSSIER']);
-
-                $dateDuJour = (new Zend_Date())->get(Zend_Date::DAY." ".Zend_Date::MONTH_NAME." ".Zend_Date::YEAR);
-                addChamp($dossInfos,'dateGeneration', $dateDuJour);
 
 				$dateComm = new Zend_Date($this->dateComm);
 				addChamp($dossInfos,'dateCommission', $dateComm->get(Zend_Date::DAY." ".Zend_Date::MONTH_NAME." ".Zend_Date::YEAR));


### PR DESCRIPTION
Permet d'utiliser la balise en en-tête du document sans devoir la répéter pour chaque dossier via la boucle